### PR TITLE
New functionality for Benders decomposition

### DIFF
--- a/src/objscip/objbenders.cpp
+++ b/src/objscip/objbenders.cpp
@@ -271,7 +271,7 @@ SCIP_DECL_BENDERSSOLVESUB(bendersSolvesubObj)
    return SCIP_OKAY;
 }
 
-
+/** method called prior to cuts being added */
 static
 SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
 {  /*lint --e{715}*/
@@ -282,10 +282,11 @@ SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
    assert(bendersdata->objbenders != NULL);
 
    /* call virtual method of benders object */
-   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, result, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
+   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
 
    return SCIP_OKAY;
 }
+
 
 /** method called after the subproblems are solved in the Benders' decomposition algorithm */
 static
@@ -300,6 +301,22 @@ SCIP_DECL_BENDERSPOSTSOLVE(bendersPostsolveObj)
    /* call virtual method of benders object */
    SCIP_CALL( bendersdata->objbenders->scip_postsolve(scip, benders, sol, type, mergecands, npriomergecands,
       nmergecands, checkint, infeasible, merged) );
+
+   return SCIP_OKAY;
+}
+
+/** method called before enforcing the constraints on a Benders' subproblem */
+static
+SCIP_DECL_BENDERSENFORCESOL(bendersEnforceSolObj)
+{  /*lint --e{715}*/
+   SCIP_BENDERSDATA* bendersdata;
+
+   bendersdata = SCIPbendersGetData(benders);
+   assert(bendersdata != NULL);
+   assert(bendersdata->objbenders != NULL);
+
+   /* call virtual method of benders object */
+   SCIP_CALL( bendersdata->objbenders->scip_enforcesol(scip, benders, sol, type, checkint, skipenforce) );
 
    return SCIP_OKAY;
 }
@@ -370,7 +387,7 @@ SCIP_RETCODE SCIPincludeObjBenders(
       objbenders->scip_cutrelax_, objbenders->scip_shareauxvars_, bendersCopyObj, bendersFreeObj, bendersInitObj,
       bendersExitObj, bendersInitpreObj, bendersExitpreObj, bendersInitsolObj, bendersExitsolObj, bendersGetvarObj,
       bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPreCutObj,
-      bendersPostsolveObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
+      bendersPostsolveObj, bendersEnforceSolObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
 
    return SCIP_OKAY; /*lint !e429*/
 }

--- a/src/objscip/objbenders.cpp
+++ b/src/objscip/objbenders.cpp
@@ -272,6 +272,21 @@ SCIP_DECL_BENDERSSOLVESUB(bendersSolvesubObj)
 }
 
 
+static
+SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
+{  /*lint --e{715}*/
+   SCIP_BENDERSDATA* bendersdata;
+
+   bendersdata = SCIPbendersGetData(benders);
+   assert(bendersdata != NULL);
+   assert(bendersdata->objbenders != NULL);
+
+   /* call virtual method of benders object */
+   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, result, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
+
+   return SCIP_OKAY;
+}
+
 /** method called after the subproblems are solved in the Benders' decomposition algorithm */
 static
 SCIP_DECL_BENDERSPOSTSOLVE(bendersPostsolveObj)
@@ -354,8 +369,8 @@ SCIP_RETCODE SCIPincludeObjBenders(
       objbenders->scip_priority_, objbenders->scip_cutlp_, objbenders->scip_cutpseudo_,
       objbenders->scip_cutrelax_, objbenders->scip_shareauxvars_, bendersCopyObj, bendersFreeObj, bendersInitObj,
       bendersExitObj, bendersInitpreObj, bendersExitpreObj, bendersInitsolObj, bendersExitsolObj, bendersGetvarObj,
-      bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPostsolveObj,
-      bendersFreesubObj, bendersdata) ); /*lint !e429*/
+      bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPreCutObj,
+      bendersPostsolveObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
 
    return SCIP_OKAY; /*lint !e429*/
 }

--- a/src/objscip/objbenders.cpp
+++ b/src/objscip/objbenders.cpp
@@ -213,7 +213,7 @@ SCIP_DECL_BENDERSCREATESUB(bendersCreatesubObj)
    assert(bendersdata->objbenders != NULL);
 
    /* call virtual method of benders object */
-   SCIP_CALL( bendersdata->objbenders->scip_createsub(scip, benders, probnumber) );
+   SCIP_CALL( bendersdata->objbenders->scip_createsub(scip, benders, probnumber, initialise) );
 
    return SCIP_OKAY;
 }

--- a/src/objscip/objbenders.h
+++ b/src/objscip/objbenders.h
@@ -216,6 +216,11 @@ public:
       return SCIP_OKAY;
    }
 
+   virtual SCIP_DECL_BENDERSPRECUT(scip_precut)
+   {  /*lint --e{715}*/
+      return SCIP_OKAY;
+   }
+
    /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
     * been solved but before they are freed.
     *  @see SCIP_DECL_BENDERSPOSTSOLVE(x) in @ref type_benders.h

--- a/src/objscip/objbenders.h
+++ b/src/objscip/objbenders.h
@@ -216,6 +216,10 @@ public:
       return SCIP_OKAY;
    }
 
+   /** called after each subproblem is solved but before the result is used to generate cuts.
+    *
+    *   @see SCIP_DECL_BENDERSPRECUT(x) in @ref type_benders.h
+    */
    virtual SCIP_DECL_BENDERSPRECUT(scip_precut)
    {  /*lint --e{715}*/
       return SCIP_OKAY;
@@ -226,6 +230,16 @@ public:
     *  @see SCIP_DECL_BENDERSPOSTSOLVE(x) in @ref type_benders.h
     */
    virtual SCIP_DECL_BENDERSPOSTSOLVE(scip_postsolve)
+   {  /*lint --e{715}*/
+      return SCIP_OKAY;
+   }
+
+   /** method called before enforcing the constraints on a Benders' subproblem. Can be used to control whether the
+    * costraint enforcing is run.
+    * 
+    *  @see SCIP_DECL_BENDERSENFORCESOL(x) in @ref type_benders.h
+    */
+   virtual SCIP_DECL_BENDERSENFORCESOL(scip_enforcesol)
    {  /*lint --e{715}*/
       return SCIP_OKAY;
    }

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -69,6 +69,7 @@
 #define SCIP_DEFAULT_EXECFEASPHASE        FALSE  /** should a feasibility phase be executed during the root node processing */
 #define SCIP_DEFAULT_SLACKVARCOEF          1e+6  /** the objective coefficient of the slack variables in the subproblem */
 #define SCIP_DEFAULT_CHECKCONSCONVEXITY    TRUE  /** should the constraints of the subproblem be checked for convexity? */
+#define SCIP_DEFAULT_USELPSOLVE            TRUE  /** TODO: add desc */
 
 #define BENDERS_MAXPSEUDOSOLS                 5  /** the maximum number of pseudo solutions checked before suggesting
                                                   *  merge candidates */
@@ -1179,6 +1180,11 @@ SCIP_RETCODE doBendersCreate(
    SCIP_CALL( SCIPsetAddBoolParam(set, messagehdlr, blkmem, paramname,
          "should the constraints of the subproblems be checked for convexity?", &(*benders)->checkconsconvexity, FALSE,
          SCIP_DEFAULT_CHECKCONSCONVEXITY, NULL, NULL) ); /*lint !e740*/
+
+   (void) SCIPsnprintf(paramname, SCIP_MAXSTRLEN, "benders/%s/useLPsolve", name);
+   SCIP_CALL( SCIPsetAddBoolParam(set, messagehdlr, blkmem, paramname,
+         "********add desc****************", &(*benders)->useLPsolve, FALSE,
+         SCIP_DEFAULT_USELPSOLVE, NULL, NULL) ); /*lint !e740*/
 
    return SCIP_OKAY;
 }

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -1014,7 +1014,7 @@ SCIP_RETCODE doBendersCreate(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/** called before enforcing the constraints on a Benders' subproblem */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/**< called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -1214,9 +1214,9 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/**< called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -5943,7 +5943,7 @@ void SCIPbendersSetPostsolve(
 /** called before enforcing the constraints on a Benders' subproblem */
 void SCIPbendersSetEnforcesol(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))/**< called before enforcing the constraints */
    )
 {
    assert(benders != NULL);

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -69,7 +69,6 @@
 #define SCIP_DEFAULT_EXECFEASPHASE        FALSE  /** should a feasibility phase be executed during the root node processing */
 #define SCIP_DEFAULT_SLACKVARCOEF          1e+6  /** the objective coefficient of the slack variables in the subproblem */
 #define SCIP_DEFAULT_CHECKCONSCONVEXITY    TRUE  /** should the constraints of the subproblem be checked for convexity? */
-#define SCIP_DEFAULT_USELPSOLVE           FALSE  /** TODO: add desc */
 
 #define BENDERS_MAXPSEUDOSOLS                 5  /** the maximum number of pseudo solutions checked before suggesting
                                                   *  merge candidates */

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -1012,8 +1012,9 @@ SCIP_RETCODE doBendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/** called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -1058,6 +1059,7 @@ SCIP_RETCODE doBendersCreate(
    (*benders)->benderssolvesub = benderssolvesub;
    (*benders)->bendersprecut = bendersprecut;
    (*benders)->benderspostsolve = benderspostsolve;
+   (*benders)->bendersenforcesol = bendersenforcesol;
    (*benders)->bendersfreesub = bendersfreesub;
    (*benders)->bendersdata = bendersdata;
    SCIP_CALL( SCIPclockCreate(&(*benders)->setuptime, SCIP_CLOCKTYPE_DEFAULT) );
@@ -1214,6 +1216,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -1225,7 +1228,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_CALL_FINALLY( doBendersCreate(benders, set, messagehdlr, blkmem, name, desc, priority, cutlp, cutpseudo,
          cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre, bendersexitpre,
          bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve, benderssolvesubconvex,
-         benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata),
+         benderssolvesub, bendersprecut, benderspostsolve, bendersenforcesol, bendersfreesub, bendersdata),
          (void) SCIPbendersFree(benders, set) );
 
    return SCIP_OKAY;
@@ -3853,8 +3856,8 @@ SCIP_RETCODE SCIPbendersExec(
             break;
 
          if (benders->bendersprecut != NULL)
-            benders->bendersprecut(set->scip, benders, sol, *result, type, subprobsolved,
-            substatus, nsubproblems, *infeasible, optimal);
+            SCIP_CALL( benders->bendersprecut(set->scip, benders, sol, type, subprobsolved,
+            substatus, nsubproblems, *infeasible, optimal) );
 
          /* Generating cuts for the subproblems. Cuts are only generated when the solution is from primal heuristics,
           * relaxations or the LP
@@ -5915,6 +5918,17 @@ void SCIPbendersSetSolvesub(
    benders->benderssolvesub = benderssolvesub;
 }
 
+/** sets the pre cut callback of Benders' decomposition */
+void SCIPbendersSetPrecut(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut))/**< called prior to cuts being added */
+   )
+{
+   assert(benders != NULL);
+
+   benders->bendersprecut = bendersprecut;
+}
+
 /** sets post-solve callback of Benders' decomposition */
 void SCIPbendersSetPostsolve(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
@@ -5925,6 +5939,18 @@ void SCIPbendersSetPostsolve(
 
    benders->benderspostsolve = benderspostsolve;
 }
+
+/** called before enforcing the constraints on a Benders' subproblem */
+void SCIPbendersSetEnforcesol(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   )
+{
+   assert(benders != NULL);
+
+   benders->bendersenforcesol = bendersenforcesol;
+}
+
 
 /** sets post-solve callback of Benders' decomposition */
 void SCIPbendersSetSubproblemComp(

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -1478,8 +1478,7 @@ SCIP_RETCODE addSlackVarsToConstraints(
  *  The MIP solving function is called to initialise the subproblem because this function calls SCIPsolve with the
  *  appropriate parameter settings for Benders' decomposition.
  */
-static
-SCIP_RETCODE initialiseSubproblem(
+SCIP_RETCODE SCIPbendersInitialiseSubproblem(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_SET*             set,                /**< global SCIP settings */
    int                   probnumber,         /**< the subproblem number */
@@ -1519,8 +1518,7 @@ SCIP_RETCODE initialiseSubproblem(
 /** initialises an LP subproblem by putting the problem into probing mode. The probing mode is invoked in a node focus
  *  event handler. This event handler is added just prior to calling the initialise subproblem function.
  */
-static
-SCIP_RETCODE initialiseLPSubproblem(
+SCIP_RETCODE SCIPbendersInitialiseLPSubproblem(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_SET*             set,                /**< global SCIP settings */
    int                   probnumber          /**< the subproblem number */
@@ -1551,7 +1549,7 @@ SCIP_RETCODE initialiseLPSubproblem(
    assert(eventhdlr != NULL);
 
    /* calling an initial solve to put the problem into probing mode */
-   SCIP_CALL( initialiseSubproblem(benders, set, probnumber, &success) );
+   SCIP_CALL( SCIPinitialiseBendersSubproblem(set->scip, benders, probnumber, &success) );
 
    return SCIP_OKAY; /*lint !e438*/
 }
@@ -1954,7 +1952,7 @@ SCIP_RETCODE createSubproblems(
                || initialise )
                && SCIPgetStage(subproblem) <= SCIP_STAGE_PROBLEM )
             {
-               SCIP_CALL( initialiseLPSubproblem(benders, set, i) );
+               SCIP_CALL( SCIPinitialiseBendersLPSubproblem(set->scip, benders, i) );
             }
          }
          else
@@ -4437,7 +4435,7 @@ SCIP_RETCODE SCIPbendersSetupSubproblem(
    {
       SCIP_Bool success;
 
-      SCIP_CALL( initialiseSubproblem(benders, set, probnumber, &success) );
+      SCIP_CALL( SCIPinitialiseBendersSubproblem(set->scip, benders, probnumber, &success) );
 
       if( !success )
       {
@@ -4613,7 +4611,7 @@ SCIP_RETCODE SCIPbendersSolveSubproblem(
          }
          else
          {
-            SCIP_CALL( initialiseSubproblem(benders, set, probnumber, &success) );
+            SCIP_CALL( SCIPinitialiseBendersSubproblem(set->scip, benders, probnumber, &success) );
          }
 
          /* if setting up the subproblem was successful */
@@ -6538,7 +6536,7 @@ SCIP_RETCODE SCIPbendersChgMastervarsToCont(
           */
          if( SCIPbendersGetSubproblemType(benders, probnumber) == SCIP_BENDERSSUBTYPE_CONVEXCONT )
          {
-            SCIP_CALL( initialiseLPSubproblem(benders, set, probnumber) );
+            SCIP_CALL( SCIPinitialiseBendersLPSubproblem(set->scip, benders, probnumber) );
          }
       }
 

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -21,6 +21,8 @@
 
 /*---+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0----+----1----+----2*/
 
+#define SCIP_DEBUG
+
 #include <assert.h>
 #include <string.h>
 
@@ -1823,7 +1825,8 @@ TERMINATE:
 static
 SCIP_RETCODE createSubproblems(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   SCIP_SET*             set                 /**< global SCIP settings */
+   SCIP_SET*             set,                /**< global SCIP settings */
+   SCIP_Bool             useLPsolve
    )
 {
    SCIP* subproblem;
@@ -1947,7 +1950,8 @@ SCIP_RETCODE createSubproblems(
          {
             /* if the user has not implemented a solve subproblem callback, then the subproblem solves are performed
              * internally. To be more efficient the subproblem is put into probing mode. */
-            if( benders->benderssolvesubconvex == NULL && benders->benderssolvesub == NULL
+            if( ( benders->benderssolvesubconvex == NULL && benders->benderssolvesub == NULL
+               || useLPsolve )
                && SCIPgetStage(subproblem) <= SCIP_STAGE_PROBLEM )
             {
                SCIP_CALL( initialiseLPSubproblem(benders, set, i) );
@@ -2063,7 +2067,7 @@ SCIP_RETCODE SCIPbendersInit(
 
    /* creates the subproblems and sets up the probing mode for LP subproblems. This function calls the benderscreatesub
     * callback. */
-   SCIP_CALL( createSubproblems(benders, set) );
+   SCIP_CALL( createSubproblems(benders, set, benders->useLPsolve) );
 
    /* storing the solution tolerance set by the SCIP parameters */
    SCIP_CALL( SCIPsetGetRealParam(set, "benders/solutiontol", &benders->solutiontol) );

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -69,7 +69,7 @@
 #define SCIP_DEFAULT_EXECFEASPHASE        FALSE  /** should a feasibility phase be executed during the root node processing */
 #define SCIP_DEFAULT_SLACKVARCOEF          1e+6  /** the objective coefficient of the slack variables in the subproblem */
 #define SCIP_DEFAULT_CHECKCONSCONVEXITY    TRUE  /** should the constraints of the subproblem be checked for convexity? */
-#define SCIP_DEFAULT_USELPSOLVE            TRUE  /** TODO: add desc */
+#define SCIP_DEFAULT_USELPSOLVE           FALSE  /** TODO: add desc */
 
 #define BENDERS_MAXPSEUDOSOLS                 5  /** the maximum number of pseudo solutions checked before suggesting
                                                   *  merge candidates */
@@ -1846,6 +1846,7 @@ SCIP_RETCODE createSubproblems(
 
    assert(benders != NULL);
    assert(set != NULL);
+   SCIPsetDebugMsg(set, "Running createSubproblems\n");
 
    /* if the subproblems have already been created, then they will not be created again. This is the case if the
     * transformed problem has been freed and then retransformed. The subproblems should only be created when the problem
@@ -1952,7 +1953,9 @@ SCIP_RETCODE createSubproblems(
          /* after checking the subproblem for convexity, if the subproblem has convex constraints and continuous variables,
           * then the problem is entered into probing mode. Otherwise, it is initialised as a CIP
           */
-         if( SCIPbendersGetSubproblemType(benders, i) == SCIP_BENDERSSUBTYPE_CONVEXCONT )
+         SCIPsetDebugMsg(set, "\nhi\n");
+         SCIPsetDebugMsg(set, "Type: %d\n", SCIPbendersGetSubproblemType(benders, i));
+         if( SCIPbendersGetSubproblemType(benders, i) == SCIP_BENDERSSUBTYPE_CONVEXCONT || useLPsolve)
          {
             /* if the user has not implemented a solve subproblem callback, then the subproblem solves are performed
              * internally. To be more efficient the subproblem is put into probing mode. */
@@ -1960,6 +1963,7 @@ SCIP_RETCODE createSubproblems(
                || useLPsolve )
                && SCIPgetStage(subproblem) <= SCIP_STAGE_PROBLEM )
             {
+               SCIPsetDebugMsg(set, "Running new code!!!!!\n");
                SCIP_CALL( initialiseLPSubproblem(benders, set, i) );
             }
          }
@@ -4177,10 +4181,14 @@ SCIP_RETCODE executeUserDefinedSolvesub(
 
    /* calls the user defined subproblem solving method. Only the convex relaxations are solved during the Large
     * Neighbourhood Benders' Search. */
+   SCIPsetDebugMsg(set, "\nProbNum: %d\n", probnumber);
+   SCIPsetDebugMsg(set, "Type: %d\n", SCIPbendersGetSubproblemType(benders, probnumber));
+   SCIPsetDebugMsg(set, "Solveloop: %d\n", solveloop);
    if( solveloop == SCIP_BENDERSSOLVELOOP_USERCONVEX )
    {
       if( benders->benderssolvesubconvex != NULL )
       {
+         SCIPsetDebugMsg(set, "Calling benderssubsolveconvex\n");
          SCIP_CALL( benders->benderssolvesubconvex(set->scip, benders, sol, probnumber,
                SCIPbendersOnlyCheckConvexRelax(benders, SCIPsetGetSubscipsOff(set)), objective, result) );
       }
@@ -4191,6 +4199,7 @@ SCIP_RETCODE executeUserDefinedSolvesub(
    {
       if( benders->benderssolvesub != NULL )
       {
+         SCIPsetDebugMsg(set, "Calling benderssubsolve\n");
          SCIP_CALL( benders->benderssolvesub(set->scip, benders, sol, probnumber, objective, result) );
       }
       else

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -21,8 +21,6 @@
 
 /*---+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0----+----1----+----2*/
 
-#define SCIP_DEBUG
-
 #include <assert.h>
 #include <string.h>
 
@@ -1534,6 +1532,15 @@ SCIP_RETCODE SCIPbendersInitialiseLPSubproblem(
 
    subproblem = SCIPbendersSubproblem(benders, probnumber);
    assert(subproblem != NULL);
+
+   /* Check an event handler doesn't already exist */
+   if (SCIPfindEventhdlr(subproblem, NODEFOCUS_EVENTHDLR_NAME) != NULL)
+   {
+      SCIPerrorMessage("Event handler for initialising an LP subproblem already exists.\n");
+      SCIPerrorMessage("To initialise a problem already with an event handler call SCIPinitialiseBendersSubproblem.\n");
+
+      return SCIP_ERROR;
+   }
 
    /* include event handler into SCIP */
    SCIP_CALL( SCIPallocBlockMemory(subproblem, &eventhdlrdata) );

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -92,6 +92,29 @@ SCIP_RETCODE SCIPbendersFree(
    SCIP_SET*             set                 /**< global SCIP settings */
    );
 
+   /** initialises a MIP subproblem by putting the problem into SCIP_STAGE_SOLVING. This is achieved by calling SCIPsolve
+ *  and then interrupting the solve in a node focus event handler.
+ *  The LP subproblem is also initialised using this method; however, a different event handler is added. This event
+ *  handler will put the LP subproblem into probing mode.
+ *  The MIP solving function is called to initialise the subproblem because this function calls SCIPsolve with the
+ *  appropriate parameter settings for Benders' decomposition.
+ */
+SCIP_RETCODE SCIPbendersInitialiseSubproblem(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_SET*             set,                /**< global SCIP settings */
+   int                   probnumber,         /**< the subproblem number */
+   SCIP_Bool*            success             /**< was the initialisation process successful */
+   );
+
+/** initialises an LP subproblem by putting the problem into probing mode. The probing mode is invoked in a node focus
+ *  event handler. This event handler is added just prior to calling the initialise subproblem function.
+ */
+SCIP_RETCODE SCIPbendersInitialiseLPSubproblem(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_SET*             set,                /**< global SCIP settings */
+   int                   probnumber          /**< the subproblem number */
+   );
+
 /** initializes Benders' decomposition */
 SCIP_RETCODE SCIPbendersInit(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -81,8 +81,9 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -366,10 +367,22 @@ void SCIPbendersSetPostsolve(
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve))/**< solving process deinitialization callback of Benders' decomposition */
    );
 
+/** sets the pre cut callback of Benders' decomposition */
+void SCIPbendersSetPrecut(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   );
+
 /** sets post-solve callback of Benders' decomposition */
 void SCIPbendersSetSubproblemComp(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp))  /**< a comparator for defining the solving order of the subproblems */
+   );
+
+/** called before enforcing the constraints on a Benders' subproblem */
+void SCIPbendersSetEnforcesol(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
    );
 
 /** sets free subproblem callback of Benders' decomposition */

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -83,7 +83,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/** called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -382,7 +382,7 @@ void SCIPbendersSetSubproblemComp(
 /** called before enforcing the constraints on a Benders' subproblem */
 void SCIPbendersSetEnforcesol(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))/**< called before enforcing the constraints */
    );
 
 /** sets free subproblem callback of Benders' decomposition */

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -81,6 +81,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */

--- a/src/scip/cons_benders.c
+++ b/src/scip/cons_benders.c
@@ -43,6 +43,7 @@
 #include "scip/cons_benders.h"
 #include "scip/heur_trysol.h"
 #include "scip/heuristics.h"
+#include "scip/struct_benders.h"
 
 
 /* fundamental constraint handler properties */
@@ -276,6 +277,14 @@ SCIP_RETCODE SCIPconsBendersEnforceSolution(
 
    for( i = 0; i < nactivebenders; i++ )
    {
+      SCIP_Bool skipenforce = FALSE;
+      SCIP_CALL( benders[i]->bendersenforcesol(scip, benders[i], sol, type, checkint, &skipenforce) );
+
+      if (skipenforce)
+      {
+         continue;
+      }
+
       switch( type )
       {
          case SCIP_BENDERSENFOTYPE_LP:

--- a/src/scip/pub_benders.h
+++ b/src/scip/pub_benders.h
@@ -341,24 +341,6 @@ void SCIPbendersSetSubproblemIsConvex(
    SCIP_Bool             isconvex            /**< flag to indicate whether the subproblem is convex */
    );
    
-SCIP_EXPORT
-void SCIPbendersSetSubproblemUseLPsolve(
-   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   int                   probnumber,         /**< the subproblem number */
-   SCIP_Bool             useLPsolve
-   );
-
-
-/** returns whether the subproblem is convex
- *
- *  This means that the dual solution can be used to generate cuts.
- */
-SCIP_EXPORT
-SCIP_Bool SCIPbendersSubproblemIsConvex(
-   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   int                   probnumber          /**< the subproblem number */
-   );
-
 /** returns the number of subproblems that are convex */
 SCIP_EXPORT
 int SCIPbendersGetNConvexSubproblems(

--- a/src/scip/pub_benders.h
+++ b/src/scip/pub_benders.h
@@ -340,6 +340,14 @@ void SCIPbendersSetSubproblemIsConvex(
    int                   probnumber,         /**< the subproblem number */
    SCIP_Bool             isconvex            /**< flag to indicate whether the subproblem is convex */
    );
+   
+SCIP_EXPORT
+void SCIPbendersSetSubproblemUseLPsolve(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber,         /**< the subproblem number */
+   SCIP_Bool             useLPsolve
+   );
+
 
 /** returns whether the subproblem is convex
  *

--- a/src/scip/pub_benders.h
+++ b/src/scip/pub_benders.h
@@ -340,7 +340,17 @@ void SCIPbendersSetSubproblemIsConvex(
    int                   probnumber,         /**< the subproblem number */
    SCIP_Bool             isconvex            /**< flag to indicate whether the subproblem is convex */
    );
-   
+
+/** returns whether the subproblem is convex
+ *
+ *  This means that the dual solution can be used to generate cuts.
+ */
+SCIP_EXPORT
+SCIP_Bool SCIPbendersSubproblemIsConvex(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber          /**< the subproblem number */
+   );
+
 /** returns the number of subproblems that are convex */
 SCIP_EXPORT
 int SCIPbendersGetNConvexSubproblems(

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -88,6 +88,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -116,7 +117,8 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre,
          bendersexitpre, bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve,
-         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata) );
+         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersenforcesol, bendersfreesub,
+         bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    return SCIP_OKAY;
@@ -168,7 +170,7 @@ SCIP_RETCODE SCIPincludeBendersBasic(
 
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersgetvar,
-         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
+         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    if( bendersptr != NULL )
@@ -492,6 +494,30 @@ SCIP_RETCODE SCIPsetBendersSolveAndFreesub(
    return SCIP_OKAY;
 }
 
+/** sets the pre cut callback of Benders' decomposition 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersPrecut(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   )
+{
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPsetBendersPrecut", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE) );
+
+   assert(benders != NULL);
+
+   SCIPbendersSetPrecut(benders, bendersprecut);
+
+   return SCIP_OKAY;
+}
+
 /** sets the post solving methods for benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
@@ -536,6 +562,30 @@ SCIP_RETCODE SCIPsetBendersSubproblemComp(
    assert(benders != NULL);
 
    SCIPbendersSetSubproblemComp(benders, benderssubcomp);
+
+   return SCIP_OKAY;
+}
+
+/** sets the callback called before enforcing the constraints on a Benders' subproblem
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersEnforcesol(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   )
+{
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPsetBendersEnforcesol", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE) );
+
+   assert(benders != NULL);
+
+   SCIPbendersSetEnforcesol(benders, bendersenforcesol);
 
    return SCIP_OKAY;
 }

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -86,7 +86,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called before enforcing the constraints */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -224,6 +224,43 @@ SCIP_RETCODE SCIPsetBendersFree(
    return SCIP_OKAY;
 }
 
+SCIP_RETCODE SCIPinitialiseBendersSubproblem(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber,         /**< the subproblem number */
+   SCIP_Bool*            success             /**< was the initialisation process successful */
+)
+{
+
+
+   assert(scip != NULL);
+   assert(scip->set != NULL);
+   assert(benders != NULL);
+   assert(probnumber >= 0 && probnumber < SCIPgetBendersNSubproblems(scip, benders));
+
+   SCIPbendersInitialiseSubproblem(benders, scip->set, probnumber, success);
+
+   return SCIP_OKAY;
+}
+
+SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber          /**< the subproblem number */
+)
+{
+
+
+   assert(scip != NULL);
+   assert(scip->set != NULL);
+   assert(benders != NULL);
+   assert(probnumber >= 0 && probnumber < SCIPgetBendersNSubproblems(scip, benders));
+
+   SCIPbendersInitialiseLPSubproblem(benders, scip->set, probnumber);
+   
+   return SCIP_OKAY;
+}
+
 /** sets initialization method of benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -86,6 +86,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
@@ -115,7 +116,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre,
          bendersexitpre, bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve,
-         benderssolvesubconvex, benderssolvesub, benderspostsolve, bendersfreesub, bendersdata) );
+         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    return SCIP_OKAY;
@@ -167,7 +168,7 @@ SCIP_RETCODE SCIPincludeBendersBasic(
 
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersgetvar,
-         benderscreatesub, NULL, NULL, NULL, NULL, NULL, bendersdata) );
+         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    if( bendersptr != NULL )

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -224,6 +224,17 @@ SCIP_RETCODE SCIPsetBendersFree(
    return SCIP_OKAY;
 }
 
+/** Initialises a MIP subproblem by putting the problem into SCIP_STAGE_SOLVING.
+ * 
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_PROBLEM
+ *       - \ref SCIP_STAGE_TRANSFORMED
+ *       - \ref SCIP_STAGE_SOLVING
+ *       - \ref SCIP_STAGE_SOLVED
+ */
 SCIP_RETCODE SCIPinitialiseBendersSubproblem(
    SCIP*                 scip,               /**< SCIP data structure */
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
@@ -231,7 +242,7 @@ SCIP_RETCODE SCIPinitialiseBendersSubproblem(
    SCIP_Bool*            success             /**< was the initialisation process successful */
 )
 {
-
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPinitialiseBendersSubproblem", FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE) );
 
    assert(scip != NULL);
    assert(scip->set != NULL);
@@ -243,13 +254,24 @@ SCIP_RETCODE SCIPinitialiseBendersSubproblem(
    return SCIP_OKAY;
 }
 
+/** Initialises an LP subproblem by putting the problem into probing mode.
+ * 
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_PROBLEM
+ *       - \ref SCIP_STAGE_TRANSFORMED
+ *       - \ref SCIP_STAGE_SOLVING
+ *       - \ref SCIP_STAGE_SOLVED
+ */
 SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(
    SCIP*                 scip,               /**< SCIP data structure */
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    int                   probnumber          /**< the subproblem number */
 )
 {
-
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPinitialiseBendersLPSubproblem", FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE) );
 
    assert(scip != NULL);
    assert(scip->set != NULL);

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -163,6 +163,21 @@ SCIP_RETCODE SCIPsetBendersFree(
    SCIP_DECL_BENDERSFREE((*bendersfree))     /**< destructor of Benders' decomposition */
    );
 
+SCIP_EXPORT
+SCIP_RETCODE SCIPinitialiseBendersSubproblem(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber,         /**< the subproblem number */
+   SCIP_Bool*            success             /**< was the initialisation process successful */
+   );
+
+SCIP_EXPORT
+SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   int                   probnumber          /**< the subproblem number */
+   );
+
 /** sets initialization method of benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -92,6 +92,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -172,6 +172,9 @@ SCIP_RETCODE SCIPsetBendersFree(
  *
  *  @pre This method can be called if SCIP is in one of the following stages:
  *       - \ref SCIP_STAGE_PROBLEM
+ *       - \ref SCIP_STAGE_TRANSFORMED
+ *       - \ref SCIP_STAGE_SOLVING
+ *       - \ref SCIP_STAGE_SOLVED
  */
 SCIP_EXPORT
 SCIP_RETCODE SCIPinitialiseBendersSubproblem(
@@ -188,6 +191,9 @@ SCIP_RETCODE SCIPinitialiseBendersSubproblem(
  *
  *  @pre This method can be called if SCIP is in one of the following stages:
  *       - \ref SCIP_STAGE_PROBLEM
+ *       - \ref SCIP_STAGE_TRANSFORMED
+ *       - \ref SCIP_STAGE_SOLVING
+ *       - \ref SCIP_STAGE_SOLVED
  */
 SCIP_EXPORT
 SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -92,8 +92,9 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -325,6 +326,22 @@ SCIP_RETCODE SCIPsetBendersSolveAndFreesub(
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub))/**< the subproblem freeing method for Benders' decomposition */
    );
 
+/** sets the pre cut callback of Benders' decomposition 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_EXPORT
+SCIP_RETCODE SCIPsetBendersPrecut(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   );
+
 /** sets the post solving methods for benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
@@ -355,6 +372,21 @@ SCIP_RETCODE SCIPsetBendersSubproblemComp(
    SCIP*                 scip,               /**< SCIP data structure */
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp))  /**< a comparator for defining the solving order of the subproblems */
+   );
+
+/** 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersEnforcesol(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
    );
 
 /** returns the Benders' decomposition of the given name, or NULL if not existing */

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -163,6 +163,14 @@ SCIP_RETCODE SCIPsetBendersFree(
    SCIP_DECL_BENDERSFREE((*bendersfree))     /**< destructor of Benders' decomposition */
    );
 
+/** Initialises a MIP subproblem by putting the problem into SCIP_STAGE_SOLVING.
+ * 
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
 SCIP_EXPORT
 SCIP_RETCODE SCIPinitialiseBendersSubproblem(
    SCIP*                 scip,               /**< SCIP data structure */
@@ -171,6 +179,14 @@ SCIP_RETCODE SCIPinitialiseBendersSubproblem(
    SCIP_Bool*            success             /**< was the initialisation process successful */
    );
 
+/** Initialises an LP subproblem by putting the problem into probing mode.
+ * 
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
 SCIP_EXPORT
 SCIP_RETCODE SCIPinitialiseBendersLPSubproblem(
    SCIP*                 scip,               /**< SCIP data structure */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -97,6 +97,7 @@ struct SCIP_Benders
                                                   adding slack variables to constraints to ensure feasibility */
    SCIP_Real             slackvarcoef;       /**< the objective coefficient of the slack variables in the subproblem */
    SCIP_Bool             checkconsconvexity; /**< should the constraints of the subproblems be checked for convexity? */
+   SCIP_Bool             useLPsolve;
 
    /* information for heuristics */
    SCIP*                 sourcescip;         /**< the source scip from when the Benders' was copied */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -62,8 +62,9 @@ struct SCIP_Benders
    SCIP_DECL_BENDERSCREATESUB((*benderscreatesub));/**< creates the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex));/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub));/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut));
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut));/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve));/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol));/** called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub));/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp)); /**< a comparator for defining the solving order of the subproblems */
    SCIP_BENDERSDATA*     bendersdata;        /**< Benders' decomposition local data */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -97,7 +97,6 @@ struct SCIP_Benders
                                                   adding slack variables to constraints to ensure feasibility */
    SCIP_Real             slackvarcoef;       /**< the objective coefficient of the slack variables in the subproblem */
    SCIP_Bool             checkconsconvexity; /**< should the constraints of the subproblems be checked for convexity? */
-   SCIP_Bool             useLPsolve;
 
    /* information for heuristics */
    SCIP*                 sourcescip;         /**< the source scip from when the Benders' was copied */
@@ -129,6 +128,7 @@ struct SCIP_Benders
    int                   nactivesubprobs;    /**< the number of active subproblems */
    SCIP_Bool             freesubprobs;       /**< do the subproblems need to be freed by the Benders' decomposition core? */
    SCIP_Bool             masterisnonlinear;  /**< flag to indicate whether the master problem contains non-linear constraints */
+   SCIP_Bool*            useLPsolve;
 
    /* cut strengthening details */
    SCIP_SOL*             corepoint;          /**< the point that is separated for stabilisation */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -62,6 +62,7 @@ struct SCIP_Benders
    SCIP_DECL_BENDERSCREATESUB((*benderscreatesub));/**< creates the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex));/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub));/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut));
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve));/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub));/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp)); /**< a comparator for defining the solving order of the subproblems */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -128,7 +128,6 @@ struct SCIP_Benders
    int                   nactivesubprobs;    /**< the number of active subproblems */
    SCIP_Bool             freesubprobs;       /**< do the subproblems need to be freed by the Benders' decomposition core? */
    SCIP_Bool             masterisnonlinear;  /**< flag to indicate whether the master problem contains non-linear constraints */
-   SCIP_Bool*            useLPsolve;
 
    /* cut strengthening details */
    SCIP_SOL*             corepoint;          /**< the point that is separated for stabilisation */

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -155,7 +155,7 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 /** the method for creating the Benders' decomposition subproblem. This method is called during the initialisation stage
  *  (after the master problem was transformed).
  *
- *  @note When the create subproblem callback is invoked, the mapping between the  master problem and subproblem
+ *  @note When the create subproblem callback is invoked, the mapping between the master problem and subproblem
  *  variables must be available. The create subproblem callback is invoked immediately after BENDERSINIT. So, it is
  *  possible to construct the variable mapping within the BENDERSINIT callback.
  *
@@ -181,7 +181,7 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
  *  - scip            : SCIP main data structure
  *  - benders         : the Benders' decomposition data structure
  *  - probnumber      : the subproblem problem number
- *  - 
+ *  - initialise      : whether to initialise the problem as an LP
  */
 #define SCIP_DECL_BENDERSCREATESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, int probnumber, SCIP_Bool* initialise)
 

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -181,8 +181,9 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
  *  - scip            : SCIP main data structure
  *  - benders         : the Benders' decomposition data structure
  *  - probnumber      : the subproblem problem number
+ *  - 
  */
-#define SCIP_DECL_BENDERSCREATESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, int probnumber)
+#define SCIP_DECL_BENDERSCREATESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, int probnumber, SCIP_Bool* initialise)
 
 /** called before the subproblem solving loop for Benders' decomposition. The pre subproblem solve function gives the
  *  user an oppportunity to perform any global set up for the Benders' decomposition.

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -284,6 +284,10 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSSOLVESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber,\
   SCIP_Real* objective, SCIP_RESULT* result)
 
+#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result,\
+  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus,\
+  int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal)
+
 /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
  * been solved but before they have been freed. After the solving of the Benders' decomposition subproblems, the
  * subproblem solving data is freed in the SCIP_DECL_BENDERSFREESUB callback. However, it is not necessary to implement

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -284,9 +284,23 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSSOLVESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber,\
   SCIP_Real* objective, SCIP_RESULT* result)
 
-#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result,\
-  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus,\
-  int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal)
+/** called during the solving loop for Benders' decomposition after a subproblem has been solved and before the solution
+ *  is used to generate cuts
+ * 
+ *  input:
+ *  - scip            : SCIP main data structure
+ *  - benders         : the Benders' decomposition data structure
+ *  - sol             : the solution that will being checked by the subproblems. Can be NULL
+ *  - type            : the type of solution being enforced
+ *  - subprobsolved   : array indicating which subproblems have been solved
+ *  - substatus       : array indicating the status of each of the subproblems
+ *  - nsubproblems    : number of subproblems
+ *  - infeasible      : is the master problem infeasible with respect to the Benders' cuts?
+ *  - optimal         : is the current solution optimal?
+ */
+#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
+  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus, int nsubproblems,\
+  SCIP_Bool infeasible, SCIP_Bool optimal)
 
 /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
  * been solved but before they have been freed. After the solving of the Benders' decomposition subproblems, the
@@ -324,6 +338,22 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSPOSTSOLVE(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
    SCIP_BENDERSENFOTYPE type, int* mergecands, int npriomergecands, int nmergecands, SCIP_Bool checkint,\
    SCIP_Bool infeasible, SCIP_Bool* merged)
+
+/** called before enforcing the constraints on a Benders' subproblem for a given solution. This allows the user
+ *  to access the data before solutions are enforced and choose whether to continue with or skip enforcement for that
+ *  subproblem
+ * 
+ *  input:
+ *  - scip            : SCIP main data structure
+ *  - benders         : the Benders' decomposition data structure
+ *  - sol             : the primal solution to enforce, or NULL for the current LP/pseudo sol
+ *  - conshdlr        : the constraint handler
+ *  - type            : the type of solution being enforced
+ *  - checkint        : is the integrality being considered when checking the subproblems
+ *  - skipenforce     : Flag to indicate wether enforcement should be doen for this subproblem or skipped
+ */
+#define SCIP_DECL_BENDERSENFORCESOL(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
+   SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* skipenforce)
 
 /** frees the subproblem so that it can be resolved in the next iteration. As stated above, it is not necessary to
  *  implement this callback. If the callback is implemented, the subproblems should be freed by calling


### PR DESCRIPTION
### Overview of changes added
- Added two new callbacks within Benders' decomposition - bendersprecut and bendersenforcesol
- Added a new initialise parameter to the benderscreatesub callback that can be used to trigger the initialisation of an LP subproblem
- Made the initialiseSubproblem and initialiseLPSubproblem functions public

**New callbacks**
Two new callbacks have been added to the benders structure along with associated setter functions and parameters to includeBenders.
bendersprecut is called just before cuts are generated for the subproblems (line 3858 of benders.c).
bendersenforcesol is called just before the constraints are enforced on a solution (line 280 of cons_benders.c). The skipenforce parameter can be set to false in order to skip enforcing for that problem.

**Initialise parameter**
A new Boolean pointer parameter - initialise - is added to the callback benderscreatesub. If this is set to true, then createSubproblems will always call SCIPinitialiseBendersLPSubproblem (line 1969 benders.c) allowing the user to later ask SCIP to use the LP solver.

**New public functions**
initialiseSubproblem and initialiseLPSubproblem have been replaced by SCIPbendersInitialiseSubproblem and SCIPbendersInitialiseLPSubproblem with public wrappers SCIPinitialiseBendersSubproblem and SCIPinitialiseBendersLPSubproblem. As with the initialsie parameter, this allows the user toinitalise the subprobles to then be solved by using the LP solver.
Both must be called in either the problem, transformed, solving or solved stage.
Since SCIPinitialiseBendersLPSubproblem creates an event handler for the problem, calling it multiple times will create an error. Instead future initialisations are done just with SCIPinitialiseBendersSubproblem - the error message informs the user of this.