### PR TITLE
New Benders callbacks

### DIFF
--- a/src/objscip/objbenders.cpp
+++ b/src/objscip/objbenders.cpp
@@ -271,7 +271,7 @@ SCIP_DECL_BENDERSSOLVESUB(bendersSolvesubObj)
    return SCIP_OKAY;
 }
 
-
+/** method called prior to cuts being added */
 static
 SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
 {  /*lint --e{715}*/
@@ -282,10 +282,11 @@ SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
    assert(bendersdata->objbenders != NULL);
 
    /* call virtual method of benders object */
-   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, result, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
+   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
 
    return SCIP_OKAY;
 }
+
 
 /** method called after the subproblems are solved in the Benders' decomposition algorithm */
 static
@@ -300,6 +301,22 @@ SCIP_DECL_BENDERSPOSTSOLVE(bendersPostsolveObj)
    /* call virtual method of benders object */
    SCIP_CALL( bendersdata->objbenders->scip_postsolve(scip, benders, sol, type, mergecands, npriomergecands,
       nmergecands, checkint, infeasible, merged) );
+
+   return SCIP_OKAY;
+}
+
+/** method called before enforcing the constraints on a Benders' subproblem */
+static
+SCIP_DECL_BENDERSENFORCESOL(bendersEnforceSolObj)
+{  /*lint --e{715}*/
+   SCIP_BENDERSDATA* bendersdata;
+
+   bendersdata = SCIPbendersGetData(benders);
+   assert(bendersdata != NULL);
+   assert(bendersdata->objbenders != NULL);
+
+   /* call virtual method of benders object */
+   SCIP_CALL( bendersdata->objbenders->scip_enforcesol(scip, benders, sol, type, checkint, skipenforce) );
 
    return SCIP_OKAY;
 }
@@ -370,7 +387,7 @@ SCIP_RETCODE SCIPincludeObjBenders(
       objbenders->scip_cutrelax_, objbenders->scip_shareauxvars_, bendersCopyObj, bendersFreeObj, bendersInitObj,
       bendersExitObj, bendersInitpreObj, bendersExitpreObj, bendersInitsolObj, bendersExitsolObj, bendersGetvarObj,
       bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPreCutObj,
-      bendersPostsolveObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
+      bendersPostsolveObj, bendersEnforceSolObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
 
    return SCIP_OKAY; /*lint !e429*/
 }

--- a/src/objscip/objbenders.cpp
+++ b/src/objscip/objbenders.cpp
@@ -272,6 +272,21 @@ SCIP_DECL_BENDERSSOLVESUB(bendersSolvesubObj)
 }
 
 
+static
+SCIP_DECL_BENDERSPRECUT(bendersPreCutObj)
+{  /*lint --e{715}*/
+   SCIP_BENDERSDATA* bendersdata;
+
+   bendersdata = SCIPbendersGetData(benders);
+   assert(bendersdata != NULL);
+   assert(bendersdata->objbenders != NULL);
+
+   /* call virtual method of benders object */
+   SCIP_CALL( bendersdata->objbenders->scip_precut(scip, benders, sol, result, type, subprobsolved, substatus, nsubproblems, infeasible, optimal) );
+
+   return SCIP_OKAY;
+}
+
 /** method called after the subproblems are solved in the Benders' decomposition algorithm */
 static
 SCIP_DECL_BENDERSPOSTSOLVE(bendersPostsolveObj)
@@ -354,8 +369,8 @@ SCIP_RETCODE SCIPincludeObjBenders(
       objbenders->scip_priority_, objbenders->scip_cutlp_, objbenders->scip_cutpseudo_,
       objbenders->scip_cutrelax_, objbenders->scip_shareauxvars_, bendersCopyObj, bendersFreeObj, bendersInitObj,
       bendersExitObj, bendersInitpreObj, bendersExitpreObj, bendersInitsolObj, bendersExitsolObj, bendersGetvarObj,
-      bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPostsolveObj,
-      bendersFreesubObj, bendersdata) ); /*lint !e429*/
+      bendersCreatesubObj, bendersPresubsolveObj, bendersSolvesubconvexObj, bendersSolvesubObj, bendersPreCutObj,
+      bendersPostsolveObj, bendersFreesubObj, bendersdata) ); /*lint !e429*/
 
    return SCIP_OKAY; /*lint !e429*/
 }

--- a/src/objscip/objbenders.h
+++ b/src/objscip/objbenders.h
@@ -216,6 +216,11 @@ public:
       return SCIP_OKAY;
    }
 
+   virtual SCIP_DECL_BENDERSPRECUT(scip_precut)
+   {  /*lint --e{715}*/
+      return SCIP_OKAY;
+   }
+
    /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
     * been solved but before they are freed.
     *  @see SCIP_DECL_BENDERSPOSTSOLVE(x) in @ref type_benders.h

--- a/src/objscip/objbenders.h
+++ b/src/objscip/objbenders.h
@@ -216,6 +216,10 @@ public:
       return SCIP_OKAY;
    }
 
+   /** called after each subproblem is solved but before the result is used to generate cuts.
+    *
+    *   @see SCIP_DECL_BENDERSPRECUT(x) in @ref type_benders.h
+    */
    virtual SCIP_DECL_BENDERSPRECUT(scip_precut)
    {  /*lint --e{715}*/
       return SCIP_OKAY;
@@ -226,6 +230,16 @@ public:
     *  @see SCIP_DECL_BENDERSPOSTSOLVE(x) in @ref type_benders.h
     */
    virtual SCIP_DECL_BENDERSPOSTSOLVE(scip_postsolve)
+   {  /*lint --e{715}*/
+      return SCIP_OKAY;
+   }
+
+   /** method called before enforcing the constraints on a Benders' subproblem. Can be used to control whether the
+    * costraint enforcing is run.
+    * 
+    *  @see SCIP_DECL_BENDERSENFORCESOL(x) in @ref type_benders.h
+    */
+   virtual SCIP_DECL_BENDERSENFORCESOL(scip_enforcesol)
    {  /*lint --e{715}*/
       return SCIP_OKAY;
    }

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -1014,7 +1014,7 @@ SCIP_RETCODE doBendersCreate(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/** called before enforcing the constraints on a Benders' subproblem */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/**< called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -1214,9 +1214,9 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/**< called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -5934,7 +5934,7 @@ void SCIPbendersSetPostsolve(
 /** called before enforcing the constraints on a Benders' subproblem */
 void SCIPbendersSetEnforcesol(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))/**< called before enforcing the constraints */
    )
 {
    assert(benders != NULL);

--- a/src/scip/benders.c
+++ b/src/scip/benders.c
@@ -1012,6 +1012,7 @@ SCIP_RETCODE doBendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
@@ -1055,6 +1056,7 @@ SCIP_RETCODE doBendersCreate(
    (*benders)->benderspresubsolve = benderspresubsolve;
    (*benders)->benderssolvesubconvex = benderssolvesubconvex;
    (*benders)->benderssolvesub = benderssolvesub;
+   (*benders)->bendersprecut = bendersprecut;
    (*benders)->benderspostsolve = benderspostsolve;
    (*benders)->bendersfreesub = bendersfreesub;
    (*benders)->bendersdata = bendersdata;
@@ -1210,6 +1212,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
@@ -1222,7 +1225,8 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_CALL_FINALLY( doBendersCreate(benders, set, messagehdlr, blkmem, name, desc, priority, cutlp, cutpseudo,
          cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre, bendersexitpre,
          bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve, benderssolvesubconvex,
-         benderssolvesub, benderspostsolve, bendersfreesub, bendersdata), (void) SCIPbendersFree(benders, set) );
+         benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata),
+         (void) SCIPbendersFree(benders, set) );
 
    return SCIP_OKAY;
 }
@@ -3838,6 +3842,10 @@ SCIP_RETCODE SCIPbendersExec(
          /* if the solving has been stopped, then the subproblem solving and cut generation must terminate */
          if( stopped )
             break;
+
+         if (benders->bendersprecut != NULL)
+            benders->bendersprecut(set->scip, benders, sol, *result, type, subprobsolved,
+            substatus, nsubproblems, *infeasible, optimal);
 
          /* Generating cuts for the subproblems. Cuts are only generated when the solution is from primal heuristics,
           * relaxations or the LP

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -81,8 +81,9 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -343,10 +344,22 @@ void SCIPbendersSetPostsolve(
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve))/**< solving process deinitialization callback of Benders' decomposition */
    );
 
+/** sets the pre cut callback of Benders' decomposition */
+void SCIPbendersSetPrecut(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   );
+
 /** sets post-solve callback of Benders' decomposition */
 void SCIPbendersSetSubproblemComp(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp))  /**< a comparator for defining the solving order of the subproblems */
+   );
+
+/** called before enforcing the constraints on a Benders' subproblem */
+void SCIPbendersSetEnforcesol(
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
    );
 
 /** sets free subproblem callback of Benders' decomposition */

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -81,6 +81,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< called prior to the subproblem solving loop */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */

--- a/src/scip/benders.h
+++ b/src/scip/benders.h
@@ -83,7 +83,7 @@ SCIP_RETCODE SCIPbendersCreate(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),/** called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -359,7 +359,7 @@ void SCIPbendersSetSubproblemComp(
 /** called before enforcing the constraints on a Benders' subproblem */
 void SCIPbendersSetEnforcesol(
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
-   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))/**< called before enforcing the constraints */
    );
 
 /** sets free subproblem callback of Benders' decomposition */

--- a/src/scip/cons_benders.c
+++ b/src/scip/cons_benders.c
@@ -43,6 +43,7 @@
 #include "scip/cons_benders.h"
 #include "scip/heur_trysol.h"
 #include "scip/heuristics.h"
+#include "scip/struct_benders.h"
 
 
 /* fundamental constraint handler properties */
@@ -276,6 +277,14 @@ SCIP_RETCODE SCIPconsBendersEnforceSolution(
 
    for( i = 0; i < nactivebenders; i++ )
    {
+      SCIP_Bool skipenforce = FALSE;
+      SCIP_CALL( benders[i]->bendersenforcesol(scip, benders[i], sol, type, checkint, &skipenforce) );
+
+      if (skipenforce)
+      {
+         continue;
+      }
+
       switch( type )
       {
          case SCIP_BENDERSENFOTYPE_LP:

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -86,7 +86,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called before enforcing the constraints */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -86,6 +86,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
@@ -115,7 +116,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre,
          bendersexitpre, bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve,
-         benderssolvesubconvex, benderssolvesub, benderspostsolve, bendersfreesub, bendersdata) );
+         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    return SCIP_OKAY;
@@ -167,7 +168,7 @@ SCIP_RETCODE SCIPincludeBendersBasic(
 
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersgetvar,
-         benderscreatesub, NULL, NULL, NULL, NULL, NULL, bendersdata) );
+         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    if( bendersptr != NULL )

--- a/src/scip/scip_benders.c
+++ b/src/scip/scip_benders.c
@@ -88,6 +88,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    )
@@ -116,7 +117,8 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, benderscopy, bendersfree, bendersinit, bendersexit, bendersinitpre,
          bendersexitpre, bendersinitsol, bendersexitsol, bendersgetvar, benderscreatesub, benderspresubsolve,
-         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersfreesub, bendersdata) );
+         benderssolvesubconvex, benderssolvesub, bendersprecut, benderspostsolve, bendersenforcesol, bendersfreesub,
+         bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    return SCIP_OKAY;
@@ -168,7 +170,7 @@ SCIP_RETCODE SCIPincludeBendersBasic(
 
    SCIP_CALL( SCIPbendersCreate(&benders, scip->set, scip->messagehdlr, scip->mem->setmem, name, desc, priority,
          cutlp, cutpseudo, cutrelax, shareauxvars, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersgetvar,
-         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
+         benderscreatesub, NULL, NULL, NULL, NULL, NULL, NULL, NULL, bendersdata) );
    SCIP_CALL( SCIPsetIncludeBenders(scip->set, benders) );
 
    if( bendersptr != NULL )
@@ -433,6 +435,30 @@ SCIP_RETCODE SCIPsetBendersSolveAndFreesub(
    return SCIP_OKAY;
 }
 
+/** sets the pre cut callback of Benders' decomposition 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersPrecut(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   )
+{
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPsetBendersPrecut", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE) );
+
+   assert(benders != NULL);
+
+   SCIPbendersSetPrecut(benders, bendersprecut);
+
+   return SCIP_OKAY;
+}
+
 /** sets the post solving methods for benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
@@ -477,6 +503,30 @@ SCIP_RETCODE SCIPsetBendersSubproblemComp(
    assert(benders != NULL);
 
    SCIPbendersSetSubproblemComp(benders, benderssubcomp);
+
+   return SCIP_OKAY;
+}
+
+/** sets the callback called before enforcing the constraints on a Benders' subproblem
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersEnforcesol(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
+   )
+{
+   SCIP_CALL( SCIPcheckStage(scip, "SCIPsetBendersEnforcesol", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE) );
+
+   assert(benders != NULL);
+
+   SCIPbendersSetEnforcesol(benders, bendersenforcesol);
 
    return SCIP_OKAY;
 }

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -92,6 +92,7 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */

--- a/src/scip/scip_benders.h
+++ b/src/scip/scip_benders.h
@@ -92,8 +92,9 @@ SCIP_RETCODE SCIPincludeBenders(
    SCIP_DECL_BENDERSPRESUBSOLVE((*benderspresubsolve)),/**< the execution method of the Benders' decomposition algorithm */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex)),/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub)),/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)),/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve)),/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol)),
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub)),/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_BENDERSDATA*     bendersdata         /**< Benders' decomposition data */
    );
@@ -294,6 +295,22 @@ SCIP_RETCODE SCIPsetBendersSolveAndFreesub(
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub))/**< the subproblem freeing method for Benders' decomposition */
    );
 
+/** sets the pre cut callback of Benders' decomposition 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_EXPORT
+SCIP_RETCODE SCIPsetBendersPrecut(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut)) /**< called prior to cuts being added */
+   );
+
 /** sets the post solving methods for benders
  *
  *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
@@ -324,6 +341,21 @@ SCIP_RETCODE SCIPsetBendersSubproblemComp(
    SCIP*                 scip,               /**< SCIP data structure */
    SCIP_BENDERS*         benders,            /**< Benders' decomposition */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp))  /**< a comparator for defining the solving order of the subproblems */
+   );
+
+/** 
+ *
+ *  @return \ref SCIP_OKAY is returned if everything worked. Otherwise a suitable error code is passed. See \ref
+ *          SCIP_Retcode "SCIP_RETCODE" for a complete list of error codes.
+ *
+ *  @pre This method can be called if SCIP is in one of the following stages:
+ *       - \ref SCIP_STAGE_INIT
+ *       - \ref SCIP_STAGE_PROBLEM
+ */
+SCIP_RETCODE SCIPsetBendersEnforcesol(
+   SCIP*                 scip,               /**< SCIP data structure */
+   SCIP_BENDERS*         benders,            /**< Benders' decomposition */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol))
    );
 
 /** returns the Benders' decomposition of the given name, or NULL if not existing */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -62,8 +62,9 @@ struct SCIP_Benders
    SCIP_DECL_BENDERSCREATESUB((*benderscreatesub));/**< creates the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex));/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub));/**< the solving method for the Benders' decomposition subproblems */
-   SCIP_DECL_BENDERSPRECUT((*bendersprecut));
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut));/**< called prior to cuts being added */
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve));/**< called after the subproblems are solved. */
+   SCIP_DECL_BENDERSENFORCESOL((*bendersenforcesol));/** called before enforcing the constraints on a Benders' subproblem */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub));/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp)); /**< a comparator for defining the solving order of the subproblems */
    SCIP_BENDERSDATA*     bendersdata;        /**< Benders' decomposition local data */

--- a/src/scip/struct_benders.h
+++ b/src/scip/struct_benders.h
@@ -62,6 +62,7 @@ struct SCIP_Benders
    SCIP_DECL_BENDERSCREATESUB((*benderscreatesub));/**< creates the Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUBCONVEX((*benderssolvesubconvex));/**< the solving method for convex Benders' decomposition subproblems */
    SCIP_DECL_BENDERSSOLVESUB((*benderssolvesub));/**< the solving method for the Benders' decomposition subproblems */
+   SCIP_DECL_BENDERSPRECUT((*bendersprecut));
    SCIP_DECL_BENDERSPOSTSOLVE((*benderspostsolve));/**< called after the subproblems are solved. */
    SCIP_DECL_BENDERSFREESUB((*bendersfreesub));/**< the freeing method for the Benders' decomposition subproblems */
    SCIP_DECL_SORTPTRCOMP((*benderssubcomp)); /**< a comparator for defining the solving order of the subproblems */

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -283,6 +283,10 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSSOLVESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber,\
   SCIP_Real* objective, SCIP_RESULT* result)
 
+#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result,\
+  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus,\
+  int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal)
+
 /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
  * been solved but before they have been freed. After the solving of the Benders' decomposition subproblems, the
  * subproblem solving data is freed in the SCIP_DECL_BENDERSFREESUB callback. However, it is not necessary to implement

--- a/src/scip/type_benders.h
+++ b/src/scip/type_benders.h
@@ -283,9 +283,23 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSSOLVESUB(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber,\
   SCIP_Real* objective, SCIP_RESULT* result)
 
-#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_RESULT result,\
-  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus,\
-  int nsubproblems, SCIP_Bool infeasible, SCIP_Bool optimal)
+/** called during the solving loop for Benders' decomposition after a subproblem has been solved and before the solution
+ *  is used to generate cuts
+ * 
+ *  input:
+ *  - scip            : SCIP main data structure
+ *  - benders         : the Benders' decomposition data structure
+ *  - sol             : the solution that will being checked by the subproblems. Can be NULL
+ *  - type            : the type of solution being enforced
+ *  - subprobsolved   : array indicating which subproblems have been solved
+ *  - substatus       : array indicating the status of each of the subproblems
+ *  - nsubproblems    : number of subproblems
+ *  - infeasible      : is the master problem infeasible with respect to the Benders' cuts?
+ *  - optimal         : is the current solution optimal?
+ */
+#define SCIP_DECL_BENDERSPRECUT(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
+  SCIP_BENDERSENFOTYPE type, SCIP_Bool* subprobsolved, SCIP_BENDERSSUBSTATUS* substatus, int nsubproblems,\
+  SCIP_Bool infeasible, SCIP_Bool optimal)
 
 /** the post-solve method for Benders' decomposition. The post-solve method is called after the subproblems have
  * been solved but before they have been freed. After the solving of the Benders' decomposition subproblems, the
@@ -323,6 +337,22 @@ typedef struct SCIP_SubproblemSolveStat SCIP_SUBPROBLEMSOLVESTAT; /**< the solvi
 #define SCIP_DECL_BENDERSPOSTSOLVE(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
    SCIP_BENDERSENFOTYPE type, int* mergecands, int npriomergecands, int nmergecands, SCIP_Bool checkint,\
    SCIP_Bool infeasible, SCIP_Bool* merged)
+
+/** called before enforcing the constraints on a Benders' subproblem for a given solution. This allows the user
+ *  to access the data before solutions are enforced and choose whether to continue with or skip enforcement for that
+ *  subproblem
+ * 
+ *  input:
+ *  - scip            : SCIP main data structure
+ *  - benders         : the Benders' decomposition data structure
+ *  - sol             : the primal solution to enforce, or NULL for the current LP/pseudo sol
+ *  - conshdlr        : the constraint handler
+ *  - type            : the type of solution being enforced
+ *  - checkint        : is the integrality being considered when checking the subproblems
+ *  - skipenforce     : Flag to indicate wether enforcement should be doen for this subproblem or skipped
+ */
+#define SCIP_DECL_BENDERSENFORCESOL(x) SCIP_RETCODE x (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,\
+   SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* skipenforce)
 
 /** frees the subproblem so that it can be resolved in the next iteration. As stated above, it is not necessary to
  *  implement this callback. If the callback is implemented, the subproblems should be freed by calling


### PR DESCRIPTION
Added two new callbacks within Benders' decomposition - bendersprecut and bendersenforcesol

Two new callbacks have been added to the benders structure along with associated setter functions and parameters to includeBenders.
bendersprecut is called just before cuts are generated for the subproblems (line 3858 of benders.c).
bendersenforcesol is called just before the constraints are enforced on a solution (line 280 of cons_benders.c). The skipenforce parameter can be set to false in order to skip enforcing for that problem.